### PR TITLE
Add withEagerlyOnce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist
+/dist-newstyle
 /cabal-dev
 .DS_Store


### PR DESCRIPTION
Add a version of `eagerlyOnce` that uses `withAsync` to avoid
leaking threads if their results are not demanded.